### PR TITLE
Fix typos in scripts

### DIFF
--- a/scripts/detailer/detailer.js
+++ b/scripts/detailer/detailer.js
@@ -23,7 +23,7 @@ const NUMBER_OF_EXECUTIONS = 100;
 
 // Directory to grab images from to execute Detailer on instead of generating new ones.
 // This must be under the Pictures folder.
-const EXISTING_IMAGES_DIRECTORY = null // Exampe usage: "DrawThings/preDetailer"
+const EXISTING_IMAGES_DIRECTORY = null // Example usage: "DrawThings/preDetailer"
 
 // The prompt to give to the detailer. 
 // Leave null if you just want to take the prompt from the UI

--- a/scripts/sd-ultimate-upscale/sd-ultimate-upscale.js
+++ b/scripts/sd-ultimate-upscale/sd-ultimate-upscale.js
@@ -1,7 +1,7 @@
 //@api-1.0
 //
 // "Scripts" is a way to enhance Draw Things experience with custom JavaScript snippets. Over time,
-// we will enhance Scripts with more APIs and do neccessary modifications on the said APIs, but we
+// we will enhance Scripts with more APIs and do necessary modifications on the said APIs, but we
 // will also keep the API stable. In particular, you can mark your script with a particular API
 // version and it will make sure we use the proper API toolchain to execute the script even in
 // the future some of the APIs changed.


### PR DESCRIPTION
## Summary
- correct spelling in Detailer comment
- fix typo in SD Ultimate Upscale documentation

## Testing
- `git status --short`