### PR TITLE
Update dynamic-prompts.js

### DIFF
--- a/scripts/dynamic-prompts/dynamic-prompts.js
+++ b/scripts/dynamic-prompts/dynamic-prompts.js
@@ -654,7 +654,9 @@ function render (promptData, batchCount){
         if (!overrideModels){
             //Apply configuration changes, if any
             finalConfiguration = Object.assign(UICONFIG, promptData.configuration);
-            finalConfiguration.loras = promptData.configuration.loras;
+            if (promptData.configuration && promptData.configuration.loras) {
+               finalConfiguration.loras = promptData.configuration.loras;
+               }
             debug.print(finalConfiguration.model);
         }
     }


### PR DESCRIPTION
Error occurs when promptData.configuration exists, but does not contain the key loras, i.e., promptData.configuration.loras is undefined.

You need to check if promptData.configuration.loras exists before trying to assign it.